### PR TITLE
chore: run bucket CORS configuration tests against moto

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
           OBJSTO_ENDPOINT: http://localhost:5000
           OBJSTO_REGION: us-east-1
         run: |
-          docker run -d -e MOTO_S3_ALLOW_CROSSACCOUNT_ACCESS=false -e MOTO_IAM_LOAD_MANAGED_POLICIES=false -e MOTO_EC2_LOAD_DEFAULT_AMIS=false -p 5000:5000 motoserver/moto:5.0.21
+          docker run -d -e MOTO_DISABLE_GLOBAL_CORS=yes -e MOTO_S3_ALLOW_CROSSACCOUNT_ACCESS=false -e MOTO_IAM_LOAD_MANAGED_POLICIES=false -e MOTO_EC2_LOAD_DEFAULT_AMIS=false -p 5000:5000 motoserver/moto:5.0.28
           
           go test -v -cover ./internal/provider/
         timeout-minutes: 10

--- a/internal/provider/bucket_cors_configuration_test.go
+++ b/internal/provider/bucket_cors_configuration_test.go
@@ -61,9 +61,6 @@ func TestAccBucketCORSConfigurationResource(t *testing.T) {
 	if testTargetIs("Minio") {
 		t.Skip("Skipping CORS configuration tests because target object storage is Minio which does not support configuring CORS settings for buckets.")
 	}
-	if testTargetIs("moto") {
-		t.Skip("Skipping CORS configuration tests because target object storage is moto which configures wildcard CORS that overrides empty bucket CORS. See https://github.com/getmoto/moto/issues/8410")
-	}
 
 	bucket_name := withSuffix("bucket-cors-configuration")
 


### PR DESCRIPTION
Depends on https://github.com/getmoto/moto/pull/8409 and waiting for the next release.